### PR TITLE
Change the error prompt of SymbolNotFound

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -36,6 +36,10 @@ impl Interpreter {
             string_table,
         }
     }
+
+    pub fn string_table(&self) -> &[String] {
+        &self.string_table
+    }
 }
 
 impl Interpreter {
@@ -343,7 +347,7 @@ impl Interpreter {
                 }
                 Ok(CrValue::Void)
             }),
-            _ => Err(Error::SymbolNotFound),
+            _ => Err(Error::SymbolNotFound(id)),
         }
     }
 

--- a/src/backend/result.rs
+++ b/src/backend/result.rs
@@ -5,7 +5,7 @@ use super::value::CrValue;
 /// Error returned by IR generator.
 pub enum Error {
     DuplicatedDef,
-    SymbolNotFound,
+    SymbolNotFound(usize),
     FailedToEval,
     InvalidArrayLen,
     InvalidInit,
@@ -26,7 +26,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::DuplicatedDef => write!(f, "duplicated symbol definition"),
-            Self::SymbolNotFound => write!(f, "symbol not found"),
+            Self::SymbolNotFound(id) => write!(f, "symbol not found, id: {id}"),
             Self::FailedToEval => write!(f, "failed to evaluate constant"),
             Self::InvalidArrayLen => write!(f, "invalid array length"),
             Self::InvalidInit => write!(f, "invalid initializer"),

--- a/src/backend/scope.rs
+++ b/src/backend/scope.rs
@@ -111,7 +111,7 @@ impl SymbolTables {
             .iter()
             .filter_map(|symt| symt.symbols.get(&id))
             .next_back();
-        f(sym.ok_or(Error::SymbolNotFound))
+        f(sym.ok_or(Error::SymbolNotFound(id)))
     }
 
     #[inline]
@@ -123,7 +123,7 @@ impl SymbolTables {
             .iter_mut()
             .filter_map(|symt| symt.symbols.get_mut(&id))
             .next_back();
-        f(sym.ok_or(Error::SymbolNotFound))
+        f(sym.ok_or(Error::SymbolNotFound(id)))
     }
 
     #[inline]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,19 @@ fn main() {
 
     let mut interpreter = Interpreter::new(strings);
 
-    #[cfg(debug_assertions)]
-    let result = interpreter.visit(&ast).unwrap();
-    #[cfg(not(debug_assertions))]
-    interpreter.visit(&ast).unwrap();
-
-    #[cfg(debug_assertions)]
-    println!("{:?}", result);
+    match interpreter.visit(&ast) {
+        #[cfg(debug_assertions)]
+        Ok(value) => println!("{:?}", value),
+        #[cfg(not(debug_assertions))]
+        Ok(_) => (),
+        Err(e) => {
+            eprintln!("on runtime error: {e}");
+            eprintln!("variables:");
+            for (i, name) in interpreter.string_table().iter().enumerate() {
+                eprintln!(" {i}:\t{name}");
+            }
+            eprintln!("{e}");
+            panic!();
+        },
+    }
 }


### PR DESCRIPTION
Change the error prompt of SymbolNotFound to make it more traceable

- output symbol id to name table
- error id info